### PR TITLE
Updating Web.config to support Certificate Credentials

### DIFF
--- a/WebAppGraphAPI/Web.config
+++ b/WebAppGraphAPI/Web.config
@@ -17,6 +17,11 @@
     <add key="ida:PostLogoutRedirectUri" value="http://localhost:44322/" />
     <add key="ida:GraphApiVersion" value="2013-11-08" />
     <add key="ida:GraphUrl" value="https://graph.windows.net" />
+    <!--
+      To authenticate using an x509 Client Certificate, populate the CertName value with the subject name of the certificate, e.g. "CN=CertName".
+      Leave CertName value empty if you want to authenticate using AppKey instead.
+      -->
+    <add key="ida:CertName" value="" />
     <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />
   </appSettings>
   <system.web>


### PR DESCRIPTION
This is an update to add a new <appSetting> for "ida:CertName" which allows a user to use a certificate to request an access token.
This corresponds to a change in Startup.Auth.cs which checks if the CertName value is populated, i.e. ( certName.Length != 0). If it is, the application will attempt to authenticate using a client certificate. If the CertName value is empty, it will use the AppKey to authenticate instead.